### PR TITLE
v1.0.4

### DIFF
--- a/CHANGELOG-1.x.md
+++ b/CHANGELOG-1.x.md
@@ -2,6 +2,10 @@
 This changelog references the relevant changes done in 1.x versions.
 
 
+## v1.0.4
+* Ensure `order_date` is updated to `published_at` value when a teaser or teaserable node is published.
+
+
 ## v1.0.3
 * Add `Triniti\AppleNews\Style\ConditionalComponentStyle` to enable conditional properties for component style.
 * Update `ArticleDocumentMarshaler::transformGoogleMapBlock` to use Map instead of Place and work with zoom level.

--- a/src/Curator/GalleryAggregate.php
+++ b/src/Curator/GalleryAggregate.php
@@ -33,6 +33,15 @@ class GalleryAggregate extends Aggregate
         $this->node->set('image_count', $event->get('image_count'));
     }
 
+    protected function applyNodePublished(Message $event): void
+    {
+        parent::applyNodePublished($event);
+
+        if ($this->node::schema()->hasMixin('triniti:curator:mixin:teaserable')) {
+            $this->node->set('order_date', $event->get('published_at'));
+        }
+    }
+
     /**
      * This is for legacy uses of command/event mixins for common
      * ncr operations. It will be removed in 3.x.

--- a/src/Curator/TeaserAggregate.php
+++ b/src/Curator/TeaserAggregate.php
@@ -34,6 +34,12 @@ class TeaserAggregate extends Aggregate
         $this->recordEvent($event);
     }
 
+    protected function applyNodePublished(Message $event): void
+    {
+        parent::applyNodePublished($event);
+        $this->node->set('order_date', $event->get('published_at'));
+    }
+
     protected function applyTeaserSlottingRemoved(Message $event): void
     {
         foreach ($event->get('slotting_keys', []) as $key) {

--- a/src/Curator/TeaserableEnricher.php
+++ b/src/Curator/TeaserableEnricher.php
@@ -31,23 +31,15 @@ final class TeaserableEnricher implements EventSubscriber, PbjxEnricher
             return;
         }
 
-        if ($pbjxEvent->hasParentEvent()) {
-            $parentEvent = $pbjxEvent->getParentEvent()->getMessage();
-            $schema = $parentEvent::schema();
-            if (!$schema->hasMixin('gdbots:pbjx:mixin:event')) {
-                return;
-            }
-
-            if ($schema->hasMixin('gdbots:ncr:mixin:node-published')
-                || $schema->usesCurie('gdbots:ncr:event:node-published')
-            ) {
-                $node->set('order_date', $parentEvent->get('published_at'));
-                return;
-            }
-        }
-
         if ($node->has('order_date')) {
             return;
+        }
+
+        if ($pbjxEvent->hasParentEvent()) {
+            $parentEvent = $pbjxEvent->getParentEvent()->getMessage();
+            if (!$parentEvent::schema()->hasMixin('gdbots:pbjx:mixin:event')) {
+                return;
+            }
         }
 
         $node->set('order_date', $node->get('created_at')->toDateTime());

--- a/src/News/ArticleAggregate.php
+++ b/src/News/ArticleAggregate.php
@@ -101,6 +101,15 @@ class ArticleAggregate extends Aggregate
         }
     }
 
+    protected function applyNodePublished(Message $event): void
+    {
+        parent::applyNodePublished($event);
+
+        if ($this->node::schema()->hasMixin('triniti:curator:mixin:teaserable')) {
+            $this->node->set('order_date', $event->get('published_at'));
+        }
+    }
+
     protected function enrichNodeUpdated(Message $event): void
     {
         /** @var Message $oldNode */

--- a/src/Ovp/VideoAggregate.php
+++ b/src/Ovp/VideoAggregate.php
@@ -114,6 +114,15 @@ class VideoAggregate extends Aggregate
             ->set('jwplayer_synced_at', $event->get('occurred_at')->getSeconds());
     }
 
+    protected function applyNodePublished(Message $event): void
+    {
+        parent::applyNodePublished($event);
+
+        if ($this->node::schema()->hasMixin('triniti:curator:mixin:teaserable')) {
+            $this->node->set('order_date', $event->get('published_at'));
+        }
+    }
+
     protected function applyTranscodingCompleted(Message $event): void
     {
         if (!$event->isInMap('tags', 'video_asset_ref')) {


### PR DESCRIPTION
* Ensure `order_date` is updated to `published_at` value when a teaser or teaserable node is published.