### PR TITLE
v1.0.5

### DIFF
--- a/CHANGELOG-1.x.md
+++ b/CHANGELOG-1.x.md
@@ -2,6 +2,10 @@
 This changelog references the relevant changes done in 1.x versions.
 
 
+## v1.0.5
+* Subscribe `NcrArticleProjector` to `apple-news-article-synced` mixin and event.
+
+
 ## v1.0.4
 * Ensure `order_date` is updated to `published_at` value when a teaser or teaserable node is published.
 

--- a/src/News/NcrArticleProjector.php
+++ b/src/News/NcrArticleProjector.php
@@ -10,8 +10,10 @@ class NcrArticleProjector extends NcrProjector
     public static function getSubscribedEvents()
     {
         return [
-            'triniti:news:mixin:article-slotting-removed' => 'onNodeEvent',
-            'triniti:news:event:article-slotting-removed' => 'onNodeEvent',
+            'triniti:news:mixin:article-slotting-removed'  => 'onNodeEvent',
+            'triniti:news:event:article-slotting-removed'  => 'onNodeEvent',
+            'triniti:news:mixin:apple-news-article-synced' => 'onNodeEvent',
+            'triniti:news:event:apple-news-article-synced' => 'onNodeEvent',
         ];
     }
 }


### PR DESCRIPTION
* Subscribe `NcrArticleProjector` to `apple-news-article-synced` mixin and event.