### PR TITLE
twitter notification send_at 3 minute buffer

### DIFF
--- a/CHANGELOG-1.x.md
+++ b/CHANGELOG-1.x.md
@@ -2,6 +2,10 @@
 This changelog references the relevant changes done in 1.x versions.
 
 
+## v1.1.1
+* Delay sending twitter notification for 3 minutes to allow users the chance to edit notification before it is sent.
+
+
 ## v1.1.0
 * Support auto post to twitter on article publish.
 

--- a/CHANGELOG-1.x.md
+++ b/CHANGELOG-1.x.md
@@ -3,7 +3,7 @@ This changelog references the relevant changes done in 1.x versions.
 
 
 ## v1.1.1
-* Delay sending twitter notification for 3 minutes to allow users the chance to edit notification before it is sent.
+* Add 3 minute buffer to twitter notification `send_at` to allow users the chance to edit notification before it is sent.
 
 
 ## v1.1.0

--- a/src/News/TwitterWatcher.php
+++ b/src/News/TwitterWatcher.php
@@ -35,7 +35,7 @@ class TwitterWatcher implements EventSubscriber
 
     protected function createTwitterNotification(Message $event, Message $article, Pbjx $pbjx): Message
     {
-        $date = $event->get('occurred_at')->toDateTime();
+        $date = $event->get('occurred_at')->toDateTime()->add(new \DateInterval('PT180S'));
         $contentRef = $article->generateNodeRef();
         $id = UuidIdentifier::fromString(
             Uuid::uuid5(
@@ -94,7 +94,7 @@ class TwitterWatcher implements EventSubscriber
         $nodeRef = $article->generateNodeRef();
 
         try {
-            $pbjx->sendAt($command, strtotime('+180 seconds'), "{$nodeRef}.post-tweet");
+            $pbjx->sendAt($command, strtotime('+3 seconds'), "{$nodeRef}.post-tweet");
         } catch (\Throwable $e) {
             if ($e->getCode() !== Code::ALREADY_EXISTS) {
                 throw $e;


### PR DESCRIPTION
* Add 3 minute buffer to twitter notification `send_at` to allow users the chance to edit notification before it is sent.
