### PR TITLE
apple news gallery image count

### DIFF
--- a/CHANGELOG-1.x.md
+++ b/CHANGELOG-1.x.md
@@ -2,6 +2,10 @@
 This changelog references the relevant changes done in 1.x versions.
 
 
+## v1.1.2
+* Reduce max gallery image count to 130 in `Triniti\AppleNews\ArticleDocumentMarshaler`
+
+
 ## v1.1.1
 * Add 3 minute buffer to twitter notification `send_at` to allow users the chance to edit notification before it is sent.
 

--- a/src/AppleNews/ArticleDocumentMarshaler.php
+++ b/src/AppleNews/ArticleDocumentMarshaler.php
@@ -711,7 +711,7 @@ class ArticleDocumentMarshaler
             ->set('gallery_ref', $nodeRef)
             ->set('status', NodeStatus::PUBLISHED())
             ->set('sort', SearchAssetsSort::GALLERY_SEQ_DESC())
-            ->set('count', 150)
+            ->set('count', 130)
             ->addToSet('types', ['image-asset']);
 
         $request->set('ctx_causator_ref', $request->generateMessageRef());


### PR DESCRIPTION
* Reduce max gallery image count to 130 in `Triniti\AppleNews\ArticleDocumentMarshaler`
