### PR TITLE
v2.1.2

### DIFF
--- a/CHANGELOG-2.x.md
+++ b/CHANGELOG-2.x.md
@@ -1,6 +1,10 @@
 # CHANGELOG for 2.x
 This changelog references the relevant changes done in 2.x versions.
 
+## v2.1.2
+* Patching `Triniti\AppleNews\SupportedUnits`, `jsonSerialize` return type.
+
+
 ## v2.1.1
 * Patching `Triniti\AppleNews\AppleNewApi` guzzle client for PHP 8.1.
 

--- a/src/AppleNews/SupportedUnits.php
+++ b/src/AppleNews/SupportedUnits.php
@@ -25,7 +25,7 @@ class SupportedUnits extends AppleNewsObject
     /**
      * {@inheritdoc}
      */
-    public function jsonSerialize(): array
+    public function jsonSerialize(): string
     {
         return $this->units;
     }


### PR DESCRIPTION
* Patching `Triniti\AppleNews\SupportedUnits`, `jsonSerialize` return type.