### PR TITLE
v2.4.1

### DIFF
--- a/CHANGELOG-2.x.md
+++ b/CHANGELOG-2.x.md
@@ -2,6 +2,10 @@
 This changelog references the relevant changes done in 2.x versions.
 
 
+## v2.4.1
+* In `\Triniti\Ovp\UpdateTranscriptionStatusHandler::handleCommand` update the Document Asset last as it is least likely to be available in the NCR. When it is unavailable the event is not applied to the Video, but that process only requires the Document Asset's NodeRef, which is known. 
+
+
 ## v2.4.0
 * Update FCM to HTTP v1 API.
 

--- a/CHANGELOG-2.x.md
+++ b/CHANGELOG-2.x.md
@@ -3,7 +3,7 @@ This changelog references the relevant changes done in 2.x versions.
 
 
 ## v2.4.1
-* In `\Triniti\Ovp\UpdateTranscriptionStatusHandler::handleCommand` update the Document Asset last as it is least likely to be available in the NCR. When it is unavailable the event is not applied to the Video, but that process only requires the Document Asset's NodeRef, which is known. 
+* In `Triniti\Ovp\UpdateTranscriptionStatusHandler::handleCommand` update the Document Asset last as it is least likely to be available in the NCR. When it is unavailable the event is not applied to the Video, but that process only requires the Document Asset's NodeRef, which is known.
 
 
 ## v2.4.0

--- a/src/Ovp/UpdateTranscriptionStatusHandler.php
+++ b/src/Ovp/UpdateTranscriptionStatusHandler.php
@@ -69,7 +69,7 @@ class UpdateTranscriptionStatusHandler implements CommandHandler
         ));
 
         /** @var NodeRef[] $linkedRefs */
-        $linkedRefs = array_merge([$documentRef], $videoAsset->get('linked_refs', []));
+        $linkedRefs = array_merge($videoAsset->get('linked_refs', []), [$documentRef]);
 
         foreach ($linkedRefs as $linkedRef) {
             $method = 'update' . StringUtil::toCamelFromSlug($linkedRef->getLabel());


### PR DESCRIPTION
* In `Triniti\Ovp\UpdateTranscriptionStatusHandler::handleCommand` update the Document Asset last as it is least likely to be available in the NCR. When it is unavailable the event is not applied to the Video, but that process only requires the Document Asset's NodeRef, which is known.