### PR TITLE
v2.4.2

### DIFF
--- a/CHANGELOG-2.x.md
+++ b/CHANGELOG-2.x.md
@@ -3,7 +3,7 @@ This changelog references the relevant changes done in 2.x versions.
 
 
 ## v2.4.2
-* In `Triniti\Dam\AssetUploader::uploadToS3` add ability to upload to s3 ingest bucket.
+* In `Triniti\Dam\AssetUploader::uploadToS3` add ability to customize bucket, key, and acl via options when uploading file to s3.
 
 
 ## v2.4.1

--- a/CHANGELOG-2.x.md
+++ b/CHANGELOG-2.x.md
@@ -2,6 +2,10 @@
 This changelog references the relevant changes done in 2.x versions.
 
 
+## v2.4.2
+* In `Triniti\Dam\AssetUploader::uploadToS3` add ability to upload to s3 ingest bucket.
+
+
 ## v2.4.1
 * In `Triniti\Ovp\UpdateTranscriptionStatusHandler::handleCommand` update the Document Asset last as it is least likely to be available in the NCR. When it is unavailable the event is not applied to the Video, but that process only requires the Document Asset's NodeRef, which is known.
 

--- a/src/Dam/AssetUploader.php
+++ b/src/Dam/AssetUploader.php
@@ -59,11 +59,11 @@ class AssetUploader
         $metadata['asset-ref'] = $this->assetIdToNodeRef($assetId)->toString();
 
         $this->s3Client->putObject([
-            'Bucket'       => $this->bucket,
-            'Key'          => $assetId->toFilePath($version, $quality),
+            'Bucket'       => $options['bucket'] ?? $this->bucket,
+            'Key'          => $options['key'] ?? $assetId->toFilePath($version, $quality),
             'SourceFile'   => $filename,
             'ContentType'  => $mimeType,
-            'ACL'          => 'public-read',
+            'ACL'          => $options['acl'] ?? 'public-read',
             'CacheControl' => 'max-age=31536000', // 1 year
             'Metadata'     => $metadata,
         ]);


### PR DESCRIPTION
* In `Triniti\Dam\AssetUploader::uploadToS3` add ability to customize bucket, key, and acl via options when uploading file to s3.