### PR TITLE
v2.6.2

### DIFF
--- a/CHANGELOG-2.x.md
+++ b/CHANGELOG-2.x.md
@@ -2,6 +2,10 @@
 This changelog references the relevant changes done in 2.x versions.
 
 
+## v2.6.2
+* Remove Guzzle timeout in `Triniti\AppleNews\AppleNewsApi`.
+
+
 ## v2.6.1
 * Increase Guzzle timeout in `Triniti\AppleNews\AppleNewsApi`.
 

--- a/src/AppleNews/AppleNewsApi.php
+++ b/src/AppleNews/AppleNewsApi.php
@@ -278,7 +278,6 @@ class AppleNewsApi
             $this->guzzleClient = new GuzzleClient([
                 'base_uri' => self::ENDPOINT,
                 'handler'  => $stack,
-                'timeout'  => 15,
             ]);
         }
 


### PR DESCRIPTION
* Remove Guzzle timeout in `Triniti\AppleNews\AppleNewsApi`.