### PR TITLE
v3.3.0

### DIFF
--- a/CHANGELOG-3.x.md
+++ b/CHANGELOG-3.x.md
@@ -2,6 +2,9 @@
 This changelog references the relevant changes done in 3.x versions.
 
 
+## v3.3.0
+* Add allowAutoplacedAds to sections for Apple News
+
 ## v3.2.0
 * Fix conditionals in TextSyles for Apple News
 

--- a/CHANGELOG-3.x.md
+++ b/CHANGELOG-3.x.md
@@ -3,7 +3,7 @@ This changelog references the relevant changes done in 3.x versions.
 
 
 ## v3.3.0
-* Add allowAutoplacedAds to sections for Apple News
+* Add allowAutoplacedAds to containers for Apple News
 
 
 ## v3.2.0

--- a/CHANGELOG-3.x.md
+++ b/CHANGELOG-3.x.md
@@ -5,6 +5,7 @@ This changelog references the relevant changes done in 3.x versions.
 ## v3.3.0
 * Add allowAutoplacedAds to sections for Apple News
 
+
 ## v3.2.0
 * Fix conditionals in TextSyles for Apple News
 

--- a/src/AppleNews/Component/Container.php
+++ b/src/AppleNews/Component/Container.php
@@ -21,6 +21,9 @@ class Container extends Component
     /** @var CollectionDisplay|HorizontalStackDisplay */
     protected $contentDisplay;
 
+    /** @var bool */
+    protected $allowAutoplacedAds;
+
     /**
      * @return ComponentLink[]
      */
@@ -155,6 +158,25 @@ class Container extends Component
         }
 
         $this->contentDisplay = $display;
+        return $this;
+    }
+
+    /**
+     * @return bool
+     */
+    public function getAllowAutoplacedAds(): bool
+    {
+        return $this->allowAutoplacedAds;
+    }
+
+    /**
+     * @param bool $allowAutoplacedAds
+     *
+     * @return static
+     */
+    public function setAllowAutoplacedAds(bool $allowAutoplacedAds = true): self
+    {
+        $this->allowAutoplacedAds = $allowAutoplacedAds;
         return $this;
     }
 

--- a/src/AppleNews/Component/Container.php
+++ b/src/AppleNews/Component/Container.php
@@ -21,7 +21,7 @@ class Container extends Component
     /** @var CollectionDisplay|HorizontalStackDisplay */
     protected $contentDisplay;
 
-    /** @var bool */
+    /** @var bool|null */
     protected $allowAutoplacedAds;
 
     /**
@@ -161,17 +161,13 @@ class Container extends Component
         return $this;
     }
 
-    /**
-     * @return bool
-     */
-    public function getAllowAutoplacedAds(): bool
+ 
+    public function getAllowAutoplacedAds(): ?bool
     {
         return $this->allowAutoplacedAds;
     }
 
     /**
-     * @param bool $allowAutoplacedAds
-     *
      * @return static
      */
     public function setAllowAutoplacedAds(bool $allowAutoplacedAds = true): self

--- a/src/AppleNews/Component/Section.php
+++ b/src/AppleNews/Component/Section.php
@@ -6,12 +6,15 @@ namespace Triniti\AppleNews\Component;
 use Triniti\AppleNews\Scene\Scene;
 
 /**
- * @link https://developer.apple.com/documentation/apple_news/section-ka8
+ * @link https://developer.apple.com/documentation/applenewsformat/section
  */
 class Section extends Container
 {
     /** @var Scene */
     protected $scene;
+
+    /** @var bool */
+    protected $allowAutoplacedAds = true;
 
     /**
      * @return Scene
@@ -33,6 +36,25 @@ class Section extends Container
         }
 
         $this->scene = $scene;
+        return $this;
+    }
+
+    /**
+     * @return bool
+     */
+    public function getAllowAutoplacedAds(): bool
+    {
+        return $this->allowAutoplacedAds;
+    }
+
+    /**
+     * @param bool $allowAutoplacedAds
+     *
+     * @return static
+     */
+    public function setAllowAutoplacedAds(bool $allowAutoplacedAds = true): self
+    {
+        $this->allowAutoplacedAds = $allowAutoplacedAds;
         return $this;
     }
 

--- a/src/AppleNews/Component/Section.php
+++ b/src/AppleNews/Component/Section.php
@@ -13,9 +13,6 @@ class Section extends Container
     /** @var Scene */
     protected $scene;
 
-    /** @var bool */
-    protected $allowAutoplacedAds = true;
-
     /**
      * @return Scene
      */
@@ -36,25 +33,6 @@ class Section extends Container
         }
 
         $this->scene = $scene;
-        return $this;
-    }
-
-    /**
-     * @return bool
-     */
-    public function getAllowAutoplacedAds(): bool
-    {
-        return $this->allowAutoplacedAds;
-    }
-
-    /**
-     * @param bool $allowAutoplacedAds
-     *
-     * @return static
-     */
-    public function setAllowAutoplacedAds(bool $allowAutoplacedAds = true): self
-    {
-        $this->allowAutoplacedAds = $allowAutoplacedAds;
         return $this;
     }
 

--- a/tests/AppleNews/Component/ContainerTest.php
+++ b/tests/AppleNews/Component/ContainerTest.php
@@ -96,6 +96,17 @@ class ContainerTest extends TestCase
         $this->assertNull($this->container->getContentDisplay());
     }
 
+    public function testGetSetAllowAutoplacedAds(): void
+    {
+        $this->assertTrue($this->container->getAllowAutoplacedAds());
+
+        $this->container->setAllowAutoplacedAds(false);
+        $this->assertFalse($this->container->getAllowAutoplacedAds());
+
+        $this->container->setAllowAutoplacedAds(true);
+        $this->assertTrue($this->container->getAllowAutoplacedAds());
+    }
+
     public function testJsonSerialize(): void
     {
         $link = new ComponentLink();
@@ -115,6 +126,18 @@ class ContainerTest extends TestCase
             ->setContentDisplay(new CollectionDisplay())
             ->setAdditions([$link])
             ->setComponents([$component]);
+
+        $this->assertJsonStringEqualsJsonString(json_encode($expected), json_encode($this->container));
+    }
+
+    public function testJsonSerializeWithAllowAutoplacedAdsDisabled(): void
+    {
+        $expected = [
+            'role'               => 'container',
+            'allowAutoplacedAds' => false,
+        ];
+
+        $this->container->setAllowAutoplacedAds(false);
 
         $this->assertJsonStringEqualsJsonString(json_encode($expected), json_encode($this->container));
     }

--- a/tests/AppleNews/Component/ContainerTest.php
+++ b/tests/AppleNews/Component/ContainerTest.php
@@ -98,8 +98,8 @@ class ContainerTest extends TestCase
 
     public function testGetSetAllowAutoplacedAds(): void
     {
-        $this->assertTrue($this->container->getAllowAutoplacedAds());
-
+        $this->assertNull($this->container->getAllowAutoplacedAds());
+        
         $this->container->setAllowAutoplacedAds(false);
         $this->assertFalse($this->container->getAllowAutoplacedAds());
 

--- a/tests/AppleNews/Component/SectionTest.php
+++ b/tests/AppleNews/Component/SectionTest.php
@@ -34,38 +34,14 @@ class SectionTest extends TestCase
         $this->assertNull($this->section->getScene());
     }
 
-    public function testGetSetAllowAutoplacedAds(): void
-    {
-        $this->assertTrue($this->section->getAllowAutoplacedAds());
-
-        $this->section->setAllowAutoplacedAds(false);
-        $this->assertFalse($this->section->getAllowAutoplacedAds());
-
-        $this->section->setAllowAutoplacedAds(true);
-        $this->assertTrue($this->section->getAllowAutoplacedAds());
-    }
-
     public function testJsonSerialize(): void
     {
         $expected = [
-            'role'               => 'section',
-            'allowAutoplacedAds' => true,
-            'scene'              => new ParallaxScaleHeader(),
+            'role'  => 'section',
+            'scene' => new ParallaxScaleHeader(),
         ];
 
         $this->section->setScene(new ParallaxScaleHeader());
-
-        $this->assertJsonStringEqualsJsonString(json_encode($expected), json_encode($this->section));
-    }
-
-    public function testJsonSerializeWithAllowAutoplacedAdsDisabled(): void
-    {
-        $expected = [
-            'role'               => 'section',
-            'allowAutoplacedAds' => false,
-        ];
-
-        $this->section->setAllowAutoplacedAds(false);
 
         $this->assertJsonStringEqualsJsonString(json_encode($expected), json_encode($this->section));
     }

--- a/tests/AppleNews/Component/SectionTest.php
+++ b/tests/AppleNews/Component/SectionTest.php
@@ -34,14 +34,38 @@ class SectionTest extends TestCase
         $this->assertNull($this->section->getScene());
     }
 
+    public function testGetSetAllowAutoplacedAds(): void
+    {
+        $this->assertTrue($this->section->getAllowAutoplacedAds());
+
+        $this->section->setAllowAutoplacedAds(false);
+        $this->assertFalse($this->section->getAllowAutoplacedAds());
+
+        $this->section->setAllowAutoplacedAds(true);
+        $this->assertTrue($this->section->getAllowAutoplacedAds());
+    }
+
     public function testJsonSerialize(): void
     {
         $expected = [
-            'role'  => 'section',
-            'scene' => new ParallaxScaleHeader(),
+            'role'               => 'section',
+            'allowAutoplacedAds' => true,
+            'scene'              => new ParallaxScaleHeader(),
         ];
 
         $this->section->setScene(new ParallaxScaleHeader());
+
+        $this->assertJsonStringEqualsJsonString(json_encode($expected), json_encode($this->section));
+    }
+
+    public function testJsonSerializeWithAllowAutoplacedAdsDisabled(): void
+    {
+        $expected = [
+            'role'               => 'section',
+            'allowAutoplacedAds' => false,
+        ];
+
+        $this->section->setAllowAutoplacedAds(false);
 
         $this->assertJsonStringEqualsJsonString(json_encode($expected), json_encode($this->section));
     }


### PR DESCRIPTION
Updated the section class to be able to set allowautoplacedads to false. Leaving the variable default to true, so it doesn't break any current section. 

https://developer.apple.com/documentation/applenewsformat/section
