### PR TITLE
tiktok

### DIFF
--- a/CHANGELOG-3.x.md
+++ b/CHANGELOG-3.x.md
@@ -2,6 +2,10 @@
 This changelog references the relevant changes done in 3.x versions.
 
 
+## v3.4.0
+* Add TikTok block support for Apple News (`TikTok` component and `transformTiktokEmbedBlock` implementation).
+
+
 ## v3.3.0
 * Add allowAutoplacedAds to containers for Apple News
 

--- a/src/AppleNews/ArticleDocumentMarshaler.php
+++ b/src/AppleNews/ArticleDocumentMarshaler.php
@@ -30,6 +30,7 @@ use Triniti\AppleNews\Component\Photo;
 use Triniti\AppleNews\Component\Place;
 use Triniti\AppleNews\Component\PullQuote;
 use Triniti\AppleNews\Component\Quote;
+use Triniti\AppleNews\Component\TikTok;
 use Triniti\AppleNews\Component\Tweet;
 use Triniti\AppleNews\Component\Video;
 use Triniti\AppleNews\Exception\ArticleNotPublished;
@@ -1096,7 +1097,19 @@ class ArticleDocumentMarshaler
      */
     protected function transformTiktokEmbedBlock(Message $block, array &$context): ?Component
     {
-        return null;
+        if (!$block->has('tiktok_id') || !$block->has('user_name')) {
+            return null;
+        }
+
+        $tiktokId = $block->get('tiktok_id');
+        $userName = $block->get('user_name');
+
+        $component = new TikTok();
+        $component
+            ->setIdentifier($block->get('etag') . $context['idx'])
+            ->setURL("https://www.tiktok.com/@{$userName}/video/{$tiktokId}");
+
+        return $component;
     }
 
     /**

--- a/src/AppleNews/Component/TikTok.php
+++ b/src/AppleNews/Component/TikTok.php
@@ -10,22 +10,13 @@ use Assert\Assertion;
  */
 class TikTok extends Component
 {
-    /** @var string */
-    protected $URL;
+    protected ?string $URL = null;
 
-    /**
-     * @return string
-     */
     public function getURL(): ?string
     {
         return $this->URL;
     }
 
-    /**
-     * @param string $url
-     *
-     * @return static
-     */
     public function setURL(string $url): self
     {
         Assertion::url($url);
@@ -33,17 +24,11 @@ class TikTok extends Component
         return $this;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function validate(): void
     {
         Assertion::notNull($this->URL);
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function jsonSerialize(): array
     {
         $properties = $this->getSetProperties();

--- a/src/AppleNews/Component/TikTok.php
+++ b/src/AppleNews/Component/TikTok.php
@@ -1,0 +1,53 @@
+<?php
+declare(strict_types=1);
+
+namespace Triniti\AppleNews\Component;
+
+use Assert\Assertion;
+
+/**
+ * @link https://developer.apple.com/documentation/apple_news/tiktok
+ */
+class TikTok extends Component
+{
+    /** @var string */
+    protected $URL;
+
+    /**
+     * @return string
+     */
+    public function getURL(): ?string
+    {
+        return $this->URL;
+    }
+
+    /**
+     * @param string $url
+     *
+     * @return static
+     */
+    public function setURL(string $url): self
+    {
+        Assertion::url($url);
+        $this->URL = $url;
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function validate(): void
+    {
+        Assertion::notNull($this->URL);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function jsonSerialize(): array
+    {
+        $properties = $this->getSetProperties();
+        $properties['role'] = 'tiktok';
+        return $properties;
+    }
+}


### PR DESCRIPTION
Adds a TikTok ANF component and wires up transformTiktokEmbedBlock in ArticleDocumentMarshaler to convert tiktok embed blocks into Apple News Format. Previously the transform returned null. Now it constructs the canonical TikTok URL from the block's user_name and tiktok_id fields.